### PR TITLE
[NH] Support sending multiple addresses to smartystreets at once

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-smartystreets "0.1.1"
+(defproject clj-smartystreets "0.1.2"
   :description "A Clojure library wrapping SmartyStreets' LiveAddress API."
   :url "https://github.com/turbovote/clj-smartystreets"
   :license {:name "Eclipse Public License"
@@ -6,6 +6,7 @@
   :lein-min-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [clj-http "0.7.6"]
-                 [midje "1.5.1"]]
+                 [midje "1.5.1"]
+                 [cheshire "5.3.1"]]
   :plugins [[lein-midje "3.1.0"]]
   :aliases {"test" ["with-profile" "+test" "midje"]})

--- a/test/clj_smartystreets/core_test.clj
+++ b/test/clj_smartystreets/core_test.clj
@@ -1,51 +1,52 @@
 (ns clj-smartystreets.core-test
   (:use [midje.sweet])
   (:require [clj-http.client :as client]
-            [clj-smartystreets.core :refer :all]))
+            [clj-smartystreets.core :refer :all]
+            [cheshire.core :refer [parse-string]]))
 
 (facts "base endpoints fetch"
-  (doseq [endpoint [{:fn street-address :url street-address-url}
-                  {:fn zipcode :url zipcode-url}]]
-    (fact "hits the streetaddress url"
-      ((:fn endpoint) {} {}) => nil
-      (provided
-        (client/request 
-          (checker [{:keys [url]}] 
-            (= url (:url endpoint)))) => nil))
-    (fact "uses a get method"
-      ((:fn endpoint) {} {}) => nil
-      (provided
-        (client/request
-          (checker [{:keys [method]}]
-            (= method :get))) => nil))
-    (fact "passes along the provided credentials"
-      ((:fn endpoint) {:auth-id "id" :auth-token "token"} {}) => nil
-      (provided
-        (client/request 
-          (checker [{{:keys [auth-id auth-token]} :query-params}] 
-            (and (= auth-id "id") 
-              (= auth-token "token")))) => nil))
-    (fact "passes along relevant parameters"
-      ((:fn endpoint) {} {:city "Pittsburgh" :state "Pennsylvania"}) => nil
-      (provided
-        (client/request
-          (checker [{{:keys [city state]} :query-params}]
-            (and (= city "Pittsburgh")
-              (= state "Pennsylvania")))) => nil))
-    (fact "removes irrelevant parameters"
-      ((:fn endpoint) {} {:badness "badness"}) => nil
-      (provided
-        (client/request
-          (checker [{:keys [query-params]}]
-            (nil? (:badness query-params)))) => nil))
-    (fact "returns the first response from the body"
-      ((:fn endpoint) {} {}) => :first
-      (provided
-        (client/request anything) => {:body [:first :second]}))))
+       (doseq [endpoint [{:fn street-address :url street-address-url}
+                         {:fn zipcode :url zipcode-url}]]
+         (fact "hits the streetaddress url"
+               ((:fn endpoint) {} {}) => nil
+               (provided
+                (client/request
+                 (checker [{:keys [url]}]
+                          (= url (:url endpoint)))) => nil))
+         (fact "uses a post method"
+               ((:fn endpoint) {} {}) => nil
+               (provided
+                (client/request
+                 (checker [{:keys [method]}]
+                          (= method :post))) => nil))
+         (fact "passes along the provided credentials"
+               ((:fn endpoint) {:auth-id "id" :auth-token "token"} {}) => nil
+               (provided
+                (client/request
+                 (checker [{{:keys [auth-id auth-token]} :query-params}]
+                          (and (= auth-id "id")
+                               (= auth-token "token")))) => nil))
+         (fact "passes along relevant parameters in the body"
+               ((:fn endpoint) {} {:city "Pittsburgh" :state "Pennsylvania"}) => nil
+               (provided
+                (client/request
+                 (checker [{body :body}]
+                          (let [{:keys [city state]} (first (parse-string body true))]
+                            (and (= city "Pittsburgh")
+                                 (= state "Pennsylvania"))))) => nil))
+         (fact "removes irrelevant parameters"
+               ((:fn endpoint) {} {:badness "badness"}) => nil
+               (provided
+                (client/request
+                 (checker [{:keys [body]}]
+                          (nil? (:badness (parse-string body true))))) => nil))
+         (fact "returns the match in the body"
+               ((:fn endpoint) {} {}) => {:input_index 0}
+               (provided
+                (client/request anything) => {:body [{:input_index 0} {:input_index 1}]}))))
 
 (facts "zipcode->city-state"
-  (fact "returns the first entry in city_states"
-    (zipcode->city-state {} "15217") => {:city "Pittsburgh" :state "Pennsylvania"}
-    (provided
-      (client/request anything) => {:body [{:city_states [{:city "Pittsburgh" :state "Pennsylvania"}]}]})))
-
+       (fact "returns the match entry in city_states"
+             (zipcode->city-state {} "15217") => {:city "Pittsburgh" :state "Pennsylvania"}
+             (provided
+              (client/request anything) => {:body [{:input_index 0 :city_states [{:city "Pittsburgh" :state "Pennsylvania"}]}]})))


### PR DESCRIPTION
The interface remains the same except now instead of just being able to pass in a single map of params (or single zipcode) you can pass in vectors or lists of either. Have fun!

Updating the midje code in here was probably the hardest part. Wow that is hard to read. Someone please put a PR with the tests rewritten in clojure.test.
