### PR TITLE
Add a new API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,1 @@
 language: clojure
-sudo: false
-cache:
-  directories:
-    - $HOME/.m2

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ namespaces is optional.
 Require it at the REPL:
 
 ```clojure
-(require '[democracyworks.smartystreets.core :as ss])
+(require '[democracyworks.smartystreets.core :as smartystreets])
 ;; Optional
-(require '[democracyworks.smartystreets.api.us-street :as us-street])
+(require '[democracyworks.smartystreets.us-street :as us-street])
 ;; Optional
-(require '[democracyworks.smartystreets.api.us-zipcode :as us-zipcode])
+(require '[democracyworks.smartystreets.us-zipcode :as us-zipcode])
 ```
 
 **OR**
@@ -36,11 +36,11 @@ Require it in your application:
 ```clojure
 (ns my-app.core
   (:require
-   [democracyworks.smartystreets.core :as ss]
+   [democracyworks.smartystreets.core :as smartystreets]
    ;; Optional
-   [democracyworks.smartystreets.api.us-street :as us-street]
+   [democracyworks.smartystreets.us-street :as us-street]
    ;; Optional
-   [democracyworks.smartystreets.api.us-zipcode :as us-zipcode]))
+   [democracyworks.smartystreets.us-zipcode :as us-zipcode]))
 ```
 
 Next, you can create a client map holding your authentication information and
@@ -50,7 +50,8 @@ pass this to the API functions to call the API:
 ;; Construct the client map. You can find the Auth ID and Auth Token in the
 ;; SmartyStreets console.
 #_=> (def client
-       (ss/client "smartystreets-auth-id" "smartystreets-auth-token"))
+       (smartystreets/client "smartystreets-auth-id"
+                             "smartystreets-auth-token"))
 
 ;; Look up a single street address.
 ;;

--- a/README.md
+++ b/README.md
@@ -1,70 +1,110 @@
 # clj-smartystreets
 
-A Clojure library wrapping SmartyStreets' LiveAddress API.
+A Clojure library wrapping
+[SmartyStreets' Cloud APIs](https://smartystreets.com/docs/cloud).
 
 [![Build Status](https://travis-ci.org/democracyworks/clj-smartystreets.svg?branch=master)](https://travis-ci.org/democracyworks/clj-smartystreets)
 
 ## Installation
 
-`clj-smartystreets` is available as a Maven artifact from
-[Clojars](http://clojars.org/clj-smartystreets):
+[Leiningen](https://github.com/technomancy/leiningen) dependency information:
+
 ```clojure
-[clj-smartystreets "0.1.6"]
+[democracyworks/clj-smartystreets "0.2.0"]
 ```
 
 ## Usage
 
-All functionality is provided by the
-`clj-smartystreets.core` namespace.
+Core functionality is provided by the `democracyworks.smartystreets.core`
+namespace. Each SmartyStreets API is in its own namespace, and inclusion of API
+namespaces is optional.
 
-Require it in the REPL:
+Require it at the REPL:
 
 ```clojure
-(require '[clj-smartystreets.core :as ss])
+(require '[democracyworks.smartystreets.core :as ss])
+;; Optional
+(require '[democracyworks.smartystreets.api.us-street :as us-street])
+;; Optional
+(require '[democracyworks.smartystreets.api.us-zipcode :as us-zipcode])
 ```
+
+**OR**
 
 Require it in your application:
 
 ```clojure
 (ns my-app.core
-  (:require [clj-smartystreets.core :as ss]))
+  (:require
+   [democracyworks.smartystreets.core :as ss]
+   ;; Optional
+   [democracyworks.smartystreets.api.us-street :as us-street]
+   ;; Optional
+   [democracyworks.smartystreets.api.us-zipcode :as us-zipcode]))
 ```
 
-Currently supports the `https://api.smartystreets.com/street-address` and `https://api.smartystreets.com/zipcode`
-endpoints. There is currently only support for single lookups.
+Next, you can create a client map holding your authentication information and
+pass this to the API functions to call the API:
 
 ```clojure
-user=> (def auth {:auth-id "auth-id" :auth-token "auth-token"})
-user=> (ss/street-address auth {:street "150 Court St" :city "Brooklyn" :state "New York" :zipcode "11201"})
-{:input_index 0, :candidate_index 0, :delivery_line_1 "150 Court St", :last_line "Brooklyn NY 11201-6771", :delivery_point_barcode "112016771996", :components {:street_name "Court", :city_name "Brooklyn", :street_suffix "St", :zipcode "11201", :state_abbreviation "NY", :plus4_code "6771", :delivery_point "99", :primary_number "150", :delivery_point_check_digit "6"}, :metadata {:zip_type "Standard", :longitude -73.99617, :carrier_route "C034", :building_default_indicator "Y", :congressional_district "07", :county_name "Kings", :elot_sort "A", :county_fips "36047", :latitude 40.69087, :elot_sequence "0099", :record_type "H", :rdi "Commercial", :precision "Zip7"}, :analysis {:dpv_match_code "D", :dpv_footnotes "AAN1", :dpv_cmra "N", :dpv_vacant "N", :active "Y", :footnotes "H#"}}
+;; Construct the client map. You can find the Auth ID and Auth Token in the
+;; SmartyStreets console.
+#_=> (def client
+       (ss/client "smartystreets-auth-id" "smartystreets-auth-token"))
 
-user=> (ss/zipcode auth {:zipcode "80202"})
-{:input_index 0, :city_states [{:city "Denver", :state_abbreviation "CO", :state "Colorado"}], :zipcodes [{:zipcode "80202", :zipcode_type "S", :county_fips "08031", :county_name "Denver", :latitude 39.747778, :longitude -104.993838}]}
+;; Look up a single street address.
+;;
+;; Note that the response is a vector, because there may be more than one
+;; potential match for the given input.
+#_=> (us-street/fetch-one client {:street "150 Court St"
+#_=>                              :city "Brooklyn"
+#_=>                              :state "New York"})
+
+[{:delivery_line_1 "150 Court St"
+  :last_line "Brooklyn NY 11201-6771"
+  :delivery_point_barcode "112016771996"
+  ; Response trimmed for brevity
+  }]
+
+;; Look up several street addresses.
+;;
+;; Note that the response is a vector of vectors, because for each input there
+;; may be more than one potential match.
+#_=> (us-street/fetch-many client [{:street "150 Court St"
+#_=>                                :city "Brooklyn"
+#_=>                                :state "New York"}
+#_=>                               {:street "1600 Pennsylvania Ave NW"
+#_=>                                :city "Washington"
+#_=>                                :state "DC"}])
+
+[[{:delivery_line_1 "150 Court St"
+   :last_line "Brooklyn NY 11201-6771"
+   ; Response trimmed for brevity
+  }]
+ [{:delivery_line_1 "1600 Pennsylvania Ave NW"
+   :last_line "Washington DC 20500-0003"
+   ; Response trimmed for brevity
+  }]]
 ```
-
-
 
 ### Exceptions
 
-HTTP exceptions are currently ignored by the library and passed on to the end user. See the LiveAddress
-API docs for an explanation of the received exceptions.
-
-```clojure
-user=> (def auth {:bad "stuff"})
-#'user/auth
-user=> (ss/zipcode auth {:zipcode "80202"})
-
-ExceptionInfo clj-http: status 401  clj-http.client/wrap-exceptions/fn--2764 (client.clj:147)
-```
+HTTP exceptions, if thrown, are not handled by the library. See the
+[Cloud API docs](https://smartystreets.com/docs/cloud) for an explanation of the
+possible HTTP status codes returned by the API, and
+[clj-http docs](https://github.com/dakrone/clj-http#exceptions) for an
+explanation of the structure of the exceptions you may receive.
 
 ## Development
 
 To run the tests:
 
-    $ lein test
+```sh
+$ lein test
+```
 
 ## License
 
-Copyright (C) 2013 Democracy Works
+Copyright © 2013-2017 Democracy Works
 
 Distributed under the Eclipse Public License, the same as Clojure.

--- a/dev-src/dev/user.clj
+++ b/dev-src/dev/user.clj
@@ -1,0 +1,14 @@
+(ns dev.user
+  (:require
+   [democracyworks.smartystreets.core :as smartystreets]
+   [democracyworks.smartystreets.us-street :as us-street]
+   [democracyworks.smartystreets.us-zipcode :as us-zipcode]))
+
+(comment "Construct a client with your own API key."
+
+(def client
+  (smartystreets/client
+   "your-auth-id"
+   "your-auth-token"))
+
+)

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -1,3 +1,0 @@
-# Introduction to clj-smartystreets
-
-TODO: write [great documentation](http://jacobian.org/writing/great-documentation/what-to-write/)

--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :url "https://github.com/democracyworks/clj-smartystreets"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-beta3"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [clj-http "3.7.0"]
                  [cheshire "5.8.0"]]
   :profiles {:dev {:dependencies [[clj-http-fake "1.0.3"]
-                                  [midje "1.9.0-alpha10"]]
+                                  [midje "1.9.0"]]
                    :repl-options {:init-ns dev.user}
                    :source-paths ["dev-src"]}}
   :plugins [[lein-midje "3.2.1"]]

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [cheshire "5.8.0"]]
   :profiles {:dev {:dependencies [[clj-http-fake "1.0.3"]
                                   [midje "1.9.0-alpha10"]]
+                   :repl-options {:init-ns dev.user}
                    :source-paths ["dev-src"]}}
   :plugins [[lein-midje "3.2.1"]]
   :aliases {"test" ["do" ["with-profile" "+test" "midje"]

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,14 @@
-(defproject clj-smartystreets "0.1.7-SNAPSHOT"
-  :description "A Clojure library wrapping SmartyStreets' LiveAddress API."
+(defproject democracyworks/clj-smartystreets "0.2.0-SNAPSHOT"
+  :description "A Clojure library wrapping SmartyStreets' Cloud APIs."
   :url "https://github.com/democracyworks/clj-smartystreets"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :lein-min-version "2.0.0"
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [clj-http "3.1.0"]
-                 [cheshire "5.6.3"]]
-  :profiles {:dev {:dependencies [[midje "1.8.3"]]}}
-  :plugins [[lein-midje "3.2"]]
-  :aliases {"test" ["with-profile" "+test" "midje"]}
-  :deploy-repositories {"releases" :clojars})
+  :dependencies [[org.clojure/clojure "1.9.0-beta3"]
+                 [clj-http "3.7.0"]
+                 [cheshire "5.8.0"]]
+  :profiles {:dev {:dependencies [[clj-http-fake "1.0.3"]
+                                  [midje "1.9.0-alpha10"]]
+                   :source-paths ["dev-src"]}}
+  :plugins [[lein-midje "3.2.1"]]
+  :aliases {"test" ["do" ["with-profile" "+test" "midje"]
+                         ["test"]]})

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [clj-http "3.7.0"]
                  [cheshire "5.8.0"]]
   :profiles {:dev {:dependencies [[clj-http-fake "1.0.3"]
-                                  [midje "1.9.0"]]
+                                  [midje "1.9.1"]]
                    :repl-options {:init-ns dev.user}
                    :source-paths ["dev-src"]}}
   :plugins [[lein-midje "3.2.1"]]

--- a/src/democracyworks/smartystreets/core.clj
+++ b/src/democracyworks/smartystreets/core.clj
@@ -1,0 +1,25 @@
+(ns democracyworks.smartystreets.core
+  (:require
+   [clj-http.client :as http]))
+
+(defrecord Client [auth-id auth-token])
+
+(defn client
+  "Returns a SmartyStreets client."
+  [auth-id auth-token]
+  (->Client auth-id auth-token))
+
+(defn http-get
+  "Make an HTTP GET call to SmartyStreets."
+  [c url query-params]
+  (http/get url {:as :json
+                 :query-params (merge (select-keys c [:auth-id :auth-token])
+                                      query-params)}))
+
+(defn http-post
+  "Make an HTTP POST call to SmartyStreets."
+  [c url body]
+  (http/post url {:as :json
+                  :content-type :json
+                  :query-params (select-keys c [:auth-id :auth-token])
+                  :form-params body}))

--- a/src/democracyworks/smartystreets/core.clj
+++ b/src/democracyworks/smartystreets/core.clj
@@ -2,24 +2,31 @@
   (:require
    [clj-http.client :as http]))
 
-(defrecord Client [auth-id auth-token])
+(defrecord Client [auth-id auth-token http-params])
 
 (defn client
   "Returns a SmartyStreets client."
-  [auth-id auth-token]
-  (->Client auth-id auth-token))
+  ([auth-id auth-token]
+   (client auth-id auth-token {}))
+  ([auth-id auth-token http-params]
+   {:pre [(string? auth-id)
+          (string? auth-token)
+          (map? http-params)]}
+   (->Client auth-id auth-token http-params)))
 
 (defn http-get
   "Make an HTTP GET call to SmartyStreets."
   [c url query-params]
-  (http/get url {:as :json
-                 :query-params (merge (select-keys c [:auth-id :auth-token])
-                                      query-params)}))
+  (let [opts {:as :json
+              :query-params (merge (select-keys c [:auth-id :auth-token])
+                                   query-params)}]
+    (http/get url (merge opts (:http-params c)))))
 
 (defn http-post
   "Make an HTTP POST call to SmartyStreets."
   [c url body]
-  (http/post url {:as :json
-                  :content-type :json
-                  :query-params (select-keys c [:auth-id :auth-token])
-                  :form-params body}))
+  (let [opts {:as :json
+              :content-type :json
+              :query-params (select-keys c [:auth-id :auth-token])
+              :form-params body}]
+    (http/post url (merge opts (:http-params c)))))

--- a/src/democracyworks/smartystreets/us_street.clj
+++ b/src/democracyworks/smartystreets/us_street.clj
@@ -1,0 +1,72 @@
+(ns democracyworks.smartystreets.us-street
+  "SmartyStreets US Street Address API
+
+  https://smartystreets.com/docs/cloud/us-street-api"
+  (:require
+   [democracyworks.smartystreets.core :as smartystreets])
+  (:import
+   (democracyworks.smartystreets.core Client)))
+
+(defprotocol API
+  (fetch-one [_ request]
+    "Retrieve a single US street address result from the API.")
+  (fetch-many [_ requests]
+    "Retrieve a collection of US street address results from the API."))
+
+;;;; HTTP implementation
+
+(def base-url
+  "https://us-street.api.smartystreets.com/street-address")
+
+(defn parse-response
+  "Transform a sequence `s` of maps containing `:input_index` and
+  `:candidate_index` into a vector of length `n` of vectors in order of
+  `:input_index` and with the sub-vectors in order of `:candidate_index`. The
+  original maps will have their `:input_index` and `:candidate_index` keys
+  removed. Top-level-vector offsets without data will contain `nil`."
+  [n s]
+  (->> (reduce (fn [acc v]
+                 (update acc
+                         (:input_index v)
+                         (fnil assoc (sorted-map))
+                         (:candidate_index v)
+                         (dissoc v :input_index :candidate_index)))
+               (vec (repeat n nil))
+               s)
+       (mapv (comp vec vals))))
+
+(defn http-fetch-one
+  "Uses `client` to send a single address `request` to the SmartyStreets API.
+
+  `request` should be an HTTP input request, described here:
+
+  https://smartystreets.com/docs/cloud/us-street-api#input-fields
+
+  Returns a vector of candidate addresses, or `nil` if no candidate addresses
+  were found."
+  [client request]
+  (->> (smartystreets/http-get client base-url request)
+       :body
+       (parse-response 1)
+       (first)))
+
+(defn http-fetch-many
+  "Uses `client` to send a collection of address `requests` to the SmartyStreets
+  API.
+
+  `requests` should be a collection of HTTP input requests, described here:
+
+  https://smartystreets.com/docs/cloud/us-street-api#input-fields
+
+  Returns a vector with results at indexes corresponding to their position in
+  `requests`. Each entry in the vector will be a vector of candidate addresses
+  returned by the API, or `nil` if there was no matching response."
+  [client requests]
+  (->> (smartystreets/http-post client base-url requests)
+       :body
+       (parse-response (count requests))))
+
+(extend Client
+  API
+  {:fetch-one http-fetch-one
+   :fetch-many http-fetch-many})

--- a/src/democracyworks/smartystreets/us_zipcode.clj
+++ b/src/democracyworks/smartystreets/us_zipcode.clj
@@ -1,0 +1,60 @@
+(ns democracyworks.smartystreets.us-zipcode
+  "SmartyStreets US Zip Code API
+
+  https://smartystreets.com/docs/cloud/us-zipcode-api"
+  (:require
+   [democracyworks.smartystreets.core :as smartystreets])
+  (:import
+   (democracyworks.smartystreets.core Client)))
+
+(defprotocol API
+  (fetch-one [_ request]
+    "Retrieve a single US zipcode result from the API.")
+  (fetch-many [_ requests]
+    "Retrieve a collection of US zipcode results from the API."))
+
+;;;; HTTP implementation
+
+(def base-url
+  "https://us-zipcode.api.smartystreets.com/lookup")
+
+(defn parse-response
+  "Transform a sequence `s` of maps containing `:input_index` into a vector with
+  entries at offsets corresponding to `:input_index`. The original maps will
+  have their `:input_index` key removed."
+  [s]
+  (mapv #(dissoc % :input_index) (sort-by :input_index s)))
+
+(defn http-fetch-one
+  "Uses `client` to send a single zipcode `request` to the SmartyStreets API.
+
+  `request` should be an HTTP input request, described here:
+
+  https://smartystreets.com/docs/cloud/us-zipcode-api#http-request-input-fields
+
+  Returns the response map API endpoint."
+  [client request]
+  (-> (smartystreets/http-get client base-url request)
+      :body
+      (parse-response)
+      (first)))
+
+(defn http-fetch-many
+  "Uses `client` to send a collection of US zipcode `requests` to the
+  SmartyStreets API.
+
+  `requests` should be a sequence of HTTP input requests, described here:
+
+  https://smartystreets.com/docs/cloud/us-zipcode-api#http-request-input-fields
+
+  Returns a vector of response maps at indexes corresponding to their position
+  in `requests`."
+  [client requests]
+  (-> (smartystreets/http-post client base-url requests)
+      :body
+      (parse-response)))
+
+(extend Client
+  API
+  {:fetch-one http-fetch-one
+   :fetch-many http-fetch-many})

--- a/test/democracyworks/smartystreets/core_test.clj
+++ b/test/democracyworks/smartystreets/core_test.clj
@@ -1,0 +1,35 @@
+(ns democracyworks.smartystreets.core-test
+  (:require
+   [clj-http.fake :as fake]
+   [clojure.test :refer [deftest is]]
+   [democracyworks.smartystreets.core :as ss]))
+
+(deftest client
+  (let [c (ss/client "id" "token")]
+    (is (= ["id" "token"]
+           ((juxt :auth-id :auth-token) c)))))
+
+(deftest http-get
+  (let [c (ss/client "id" "token")]
+    (fake/with-fake-routes {"http://localhost?auth-id=id&auth-token=token&foo=bar"
+                            (fn [req]
+                              {:status 200
+                               :body "{}"})}
+      (is (= {} (-> (ss/http-get
+                     c
+                     "http://localhost"
+                     {:foo "bar"})
+                    :body))))))
+
+(deftest http-post
+  (let [c (ss/client "id" "token")]
+    (fake/with-fake-routes {"http://localhost?auth-id=id&auth-token=token"
+                            {:post
+                             (fn [req]
+                               {:status 200
+                                :body "[{}]"})}}
+      (is (= [{}] (-> (ss/http-post
+                       c
+                       "http://localhost"
+                       {:foo "bar"})
+                      :body))))))

--- a/test/democracyworks/smartystreets/core_test.clj
+++ b/test/democracyworks/smartystreets/core_test.clj
@@ -1,34 +1,42 @@
 (ns democracyworks.smartystreets.core-test
   (:require
    [clj-http.fake :as fake]
-   [clojure.test :refer [deftest is]]
-   [democracyworks.smartystreets.core :as ss]))
+   [clojure.test :refer [deftest is testing]]
+   [democracyworks.smartystreets.core :as smartystreets]))
 
 (deftest client
-  (let [c (ss/client "id" "token")]
-    (is (= ["id" "token"]
-           ((juxt :auth-id :auth-token) c)))))
+  (testing "2-arity version"
+    (let [c (smartystreets/client "id" "token")]
+      (is (= ["id" "token"]
+             ((juxt :auth-id :auth-token) c)))))
+  (testing "3-arity version"
+    (let [c (smartystreets/client "id" "token" {:foo "bar"})]
+      (is (= ["id" "token" {:foo "bar"}]
+             ((juxt :auth-id :auth-token :http-params) c)))))
+  (testing "bogus arguments not allowed"
+    (is (thrown? AssertionError
+                 (smartystreets/client nil nil nil)))))
 
 (deftest http-get
-  (let [c (ss/client "id" "token")]
+  (let [c (smartystreets/client "id" "token")]
     (fake/with-fake-routes {"http://localhost?auth-id=id&auth-token=token&foo=bar"
                             (fn [req]
                               {:status 200
                                :body "{}"})}
-      (is (= {} (-> (ss/http-get
+      (is (= {} (-> (smartystreets/http-get
                      c
                      "http://localhost"
                      {:foo "bar"})
                     :body))))))
 
 (deftest http-post
-  (let [c (ss/client "id" "token")]
+  (let [c (smartystreets/client "id" "token")]
     (fake/with-fake-routes {"http://localhost?auth-id=id&auth-token=token"
                             {:post
                              (fn [req]
                                {:status 200
                                 :body "[{}]"})}}
-      (is (= [{}] (-> (ss/http-post
+      (is (= [{}] (-> (smartystreets/http-post
                        c
                        "http://localhost"
                        {:foo "bar"})

--- a/test/democracyworks/smartystreets/us_street_test.clj
+++ b/test/democracyworks/smartystreets/us_street_test.clj
@@ -1,0 +1,44 @@
+(ns democracyworks.smartystreets.us-street-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is]]
+   [clj-http.fake :as fake]
+   [democracyworks.smartystreets.core :as smartystreets]
+   [democracyworks.smartystreets.us-street :as us-street]))
+
+(def client
+  (smartystreets/client "id" "token"))
+
+(deftest parse-response
+  (let [data [{:input_index 0 :candidate_index 0 :t "a"}
+              {:input_index 2 :candidate_index 1 :t "c"}
+              {:input_index 2 :candidate_index 0 :t "b"}]
+        result [[{:t "a"}]
+                []
+                [{:t "b"}
+                 {:t "c"}]]]
+    (is (= result (us-street/parse-response 3 data)))))
+
+(deftest http-fetch-one
+  (let [response-data [{:input_index 0 :candidate_index 0 :t "a"}
+                       {:input_index 0 :candidate_index 1 :t "b"}]]
+    (fake/with-fake-routes {(str us-street/base-url
+                                 "?auth-id=id&auth-token=token")
+                            {:get
+                             (fn [req]
+                               {:status 200
+                                :body (json/generate-string response-data)})}}
+      (is (= [{:t "a"} {:t "b"}]
+             (us-street/fetch-one client {}))))))
+
+(deftest http-fetch-many
+  (let [response-data [{:input_index 0 :candidate_index 0 :t "a"}
+                       {:input_index 0 :candidate_index 1 :t "b"}]]
+    (fake/with-fake-routes {(str us-street/base-url
+                                 "?auth-id=id&auth-token=token")
+                            {:post
+                             (fn [req]
+                               {:status 200
+                                :body (json/generate-string response-data)})}}
+      (is (= [[{:t "a"} {:t "b"}]]
+             (us-street/fetch-many client [{:street "123 Test St"}]))))))

--- a/test/democracyworks/smartystreets/us_zipcode_test.clj
+++ b/test/democracyworks/smartystreets/us_zipcode_test.clj
@@ -1,0 +1,43 @@
+(ns democracyworks.smartystreets.us-zipcode-test
+  (:require
+   [cheshire.core :as json]
+   [clojure.test :refer [deftest is]]
+   [clj-http.fake :as fake]
+   [democracyworks.smartystreets.core :as smartystreets]
+   [democracyworks.smartystreets.us-zipcode :as us-zipcode]))
+
+(def client
+  (smartystreets/client "id" "token"))
+
+(deftest parse-response
+  (let [data [{:input_index 0 :t "a"}
+              {:input_index 2 :t "c"}
+              {:input_index 1 :t "b"}]
+        result [{:t "a"}
+                {:t "b"}
+                {:t "c"}]]
+    (is (= result (us-zipcode/parse-response data)))))
+
+(deftest fetch-one
+  (let [response-data [{:input_index 0 :t "a"}]]
+    (fake/with-fake-routes {(str us-zipcode/base-url
+                                 "?auth-id=id&auth-token=token")
+                            {:get
+                             (fn [req]
+                               {:status 200
+                                :body (json/generate-string response-data)})}}
+      (is (= {:t "a"}
+             (us-zipcode/fetch-one client {}))))))
+
+(deftest fetch-many
+  (let [response-data [{:input_index 0 :t "a"}
+                       {:input_index 1 :t "b"}]]
+    (fake/with-fake-routes {(str us-zipcode/base-url
+                                 "?auth-id=id&auth-token=token")
+                            {:post
+                             (fn [req]
+                               {:status 200
+                                :body (json/generate-string response-data)})}}
+      (is (= [{:t "a"} {:t "b"}]
+             (us-zipcode/fetch-many client [{:street "123 Test St"}
+                                            {:street "234 Test St"}]))))))


### PR DESCRIPTION
In preparation for future address geocoding improvements, we need to change the way we parse SmartyStreets' API responses.

The existing code has the following assumption at its core:

```clojure
(defn- query->response [responses idx query]
  (first (filter #(= idx (:input_index %)) responses)))
```

The problem with the above is that responses with multiple candidate addresses have all but the first candidate address stripped from the response. In order to change this assumption without breaking existing consumers, we need a new API that better models address responses. This new API has been added in the form of new namespaces. No code has been removed, so existing software should be able to pull down the new artifact and continue to use the library.

The overall goal of the changes is to wrap the SmartyStreets API as directly as possible. Aside from the general structure of requests and responses, we are agnostic to particular fields in requests or responses.

In general, the only transformations done to the API responses are to map flat responses containing `input_index` and `candidate_index` fields into vectors (nested in the case of responses with `candidate_index`).

In order to support multiple candidate addresses in the US Street API, each address in the input will correspond to a vector of zero or more candidate addresses.

Other changes:

* We now use the `democracyworks` groupId to be a bit more neighborly
* Version is tentatively bumped to `0.2.0-SNAPSHOT` - if released, it will be released at `0.2.0`